### PR TITLE
Fix: Atualizar versão do plugin desktop para v1.2.0 e remover dependência obsoleta

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -51,7 +51,6 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(libs.core)
             implementation(libs.zoop.pos.plugin.desktop.android)
-            implementation("com.github.mik3y:usb-serial-for-android:3.8.0")
         }
 
         commonMain.dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ kotlinx-coroutines = "1.9.0"
 kotlinxCoroutinesCore = "1.6.0"
 lifecycleViewmodelCompose = "2.6.0"
 lifecycleViewmodelKtx = "2.4.0"
-zoopPosPluginDesktop = "1.1.2"
+zoopPosPluginDesktop = "1.2.0"
 
 [libraries]
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Atualização do plugin Zoop POS Desktop para v1.2.0

- Remoção da dependência USB Serial não utilizada


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.gradle.kts</strong><dd><code>Remoção de dependência USB Serial obsoleta</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composeApp/build.gradle.kts

<li>Remoção da dependência "com.github.mik3y:usb-serial-for-android:3.8.0" <br>que não era mais necessária


</details>


  </td>
  <td><a href="https://github.com/getzoop/zoop-sample-desktop/pull/5/files#diff-9ea83bf74425e7270f5dd624644cc4500977afeb671f9578fabdec009eb4ba4a">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>libs.versions.toml</strong><dd><code>Atualização da versão do plugin Zoop POS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

gradle/libs.versions.toml

<li>Atualização da versão do plugin Zoop POS Desktop de 1.1.2 para 1.2.0


</details>


  </td>
  <td><a href="https://github.com/getzoop/zoop-sample-desktop/pull/5/files#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87df">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>